### PR TITLE
Showing initial slide in infinite loop when going backwards (previous)

### DIFF
--- a/src/whirligig.js
+++ b/src/whirligig.js
@@ -229,13 +229,13 @@ export default class Track extends Component {
     const lastIndex = childCount - slideBy
 
     if (!slideBy) {
-      const [prevSlide] = this.getPartiallyObscuredSlides()
-      const prevInfinteSlide = (prevSlide === firstIndex) ? childCount - 1 : prevSlide
+      const [prevSlide] = Math.max(activeIndex - 1, firstIndex)
+      const prevInfinteSlide = (prevSlide === activeIndex) ? childCount - 1 : prevSlide
       return this.slideTo(infinite ? prevInfinteSlide : prevSlide)
     }
 
     const nextActive = Math.max(activeIndex - slideBy, firstIndex)
-    const nextActiveInfinite = (nextActive === firstIndex) ? lastIndex : nextActive
+    const nextActiveInfinite = (activeIndex === firstIndex) ? lastIndex : nextActive
     return this.slideTo(infinite ? nextActiveInfinite : nextActive)
   }
 

--- a/src/whirligig.js
+++ b/src/whirligig.js
@@ -229,7 +229,7 @@ export default class Track extends Component {
     const lastIndex = childCount - slideBy
 
     if (!slideBy) {
-      const [prevSlide] = Math.max(activeIndex - 1, firstIndex)
+      const prevSlide = Math.max(activeIndex - 1, firstIndex)
       const prevInfinteSlide = (prevSlide === activeIndex) ? childCount - 1 : prevSlide
       return this.slideTo(infinite ? prevInfinteSlide : prevSlide)
     }


### PR DESCRIPTION
## Change Details
When going to previous slide while in infinite loop initial slide was skipped due to minor logic inconsistencies.
I have replaced this.getPartiallyObscuredSlides() with Math.max(activeIndex - 1, firstIndex) because this function is behaving strange and causes slider to show same slide as previous over and over. This is an issue on your demo where it breaks as slide nr 12.

Lines 233 and 238 are actually the same. They won't set slide index to last slide until initial slide is showing (until it is active)

## Change Type

* [ ] Feature
* [ ] Chore
* [x ] Bug Fix

## Change Level

* [ ] major
* [ ] minor
* [x ] patch

## Checklist
* [ ] Added tests / Task did not decrease code coverage
* [ ] If UI change, tested across browsers

#### Other Context (if appropriate)

#### Screenshots (if appropriate)
