### PR TITLE
Add snapPositionOffset to allow for custom carousel gutter [minor]

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,11 @@ component to directly control when and where the whirligig transitions to.
 A boolean flag that turns on/off the snap-to-slide feature. If set, the
 Whirligig will animate the final bit of scrolling to stop at a slide.
 
+### `snapPositionOffset: number = 0`
+
+A number that assigns offset to slides on next() and prev() or snap. As an example, this allows a full-width
+Slider to select a starting/ending slide position inside of the container, rather than to the edge.
+
 ### `startAt: number = 0`
 
 The Slide index that will be the "active" slide when the Whirligig mounts. The value

--- a/src/whirligig.js
+++ b/src/whirligig.js
@@ -29,6 +29,7 @@ export default class Whirligig extends React.Component {
     preventAutoCorrect: false,
     preventScroll: false,
     preventSwipe: false,
+    snapPositionOffset: 0,
     snapToSlide: false,
     startAt: 0,
     style: {},
@@ -254,11 +255,13 @@ export default class Whirligig extends React.Component {
       animationDuration: duration,
       infinite,
       preventScroll,
+      snapPositionOffset,
     } = this.props
     const { children, scrollLeft } = this.whirligig
     const slideIndex = normalizeIndex(index, this.childCount, infinite)
     const startingIndex = this.state.activeIndex
-    const delta = children[slideIndex].offsetLeft - scrollLeft
+    const delta =
+      children[slideIndex].offsetLeft - scrollLeft - snapPositionOffset
     if (startingIndex !== slideIndex) {
       beforeSlide(index)
     }


### PR DESCRIPTION
## Change Type

* [ ] Feature
* [ ] Chore
* [ ] Bug Fix

## Change Level

* [ ] major
* [x] minor
* [ ] patch

## Further Information (screenshots, etc)
This allows the passing of the 'snapPositionOffset' number to allow spacing on each snap.
Example with a full-width container, but the slides need to align with other content:
![snap](https://user-images.githubusercontent.com/9059888/73668490-284c0a00-4663-11ea-8981-c261572bf6ba.gif)

#### Relevant Links (bug reports, etc)

## Checklist

* [ ] Added tests / did not decrease code coverage
* [ ] Tested across browsers
