### PR TITLE
Fix snapPositionOffset prop from being spread on the div.

### DIFF
--- a/src/whirligig.js
+++ b/src/whirligig.js
@@ -323,6 +323,7 @@ export default class Whirligig extends React.Component {
       preventAutoCorrect,
       preventSwipe,
       snapToSlide,
+      snapPositionOffset,
       onSlideClick,
       slideClass,
       slideTo,


### PR DESCRIPTION
## Change Type

* [ ] Feature
* [ ] Chore
* [x] Bug Fix

## Change Level

* [ ] major
* [ ] minor
* [x] patch

## Further Information (screenshots, etc)

This prop was being spread to the native elements.

#### Relevant Links (bug reports, etc)

Closes #64

## Checklist

* [ ] Added tests / did not decrease code coverage
* [ ] Tested across browsers
